### PR TITLE
SIDEBAR_MINIMIZER can not do toggle if home page has no SIDEBAR_MINIMIZER and Turbolinks navigate to other page

### DIFF
--- a/app/javascript/controllers/coreui_sidebar_controller.js
+++ b/app/javascript/controllers/coreui_sidebar_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "stimulus";
+
+const SIDEBAR_MINIMIZER = 'button.sidebar-minimizer';
+
+export default class extends Controller {
+  connect() {
+    $(SIDEBAR_MINIMIZER).on('click', this.handleStoreSidebarStates);
+    if(localStorage.getItem('coreui-sidebar-minimized') == 'true') {
+      setTimeout(function(){
+        $(SIDEBAR_MINIMIZER).click();
+        setTimeout(function(){
+          $('body').addClass('sidebar-minimized');
+        }, 150);
+      }, 20);
+    }
+  }
+
+  handleStoreSidebarStates = (event) => {
+    setTimeout(function(){
+      if($('body.sidebar-minimized').length) {
+        localStorage.setItem('coreui-sidebar-minimized', true);
+      } else {
+        localStorage.removeItem('coreui-sidebar-minimized');
+      }
+    }, 200);
+  }
+
+  disconnect() {
+    if($('body.sidebar-minimized').length) {
+      localStorage.setItem('coreui-sidebar-minimized', true);
+    }
+    $(SIDEBAR_MINIMIZER).off('click', this.handleStoreSidebarStates);
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,10 @@
+// Load all the controllers within this directory and all subdirectories.
+// Controller files must be named *_controller.js.
+
+import { Application } from "stimulus"
+import { definitionsFromContext } from "stimulus/webpack-helpers"
+
+const application = Application.start()
+const context = require.context("controllers", true, /_controller\.js$/)
+application.load(definitionsFromContext(context))
+

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -23,3 +23,6 @@ require("@rails/ujs").start()
 require("turbolinks").start()
 //require("@rails/activestorage").start()
 require("channels")
+
+import "controllers";
+

--- a/app/views/layouts/sidebars/_accounts.html.erb
+++ b/app/views/layouts/sidebars/_accounts.html.erb
@@ -1,4 +1,4 @@
-<div class="sidebar">
+<div class="sidebar" data-controller="coreui-sidebar">
   <nav class="sidebar-nav">
     <ul class="nav">
       <%= nav_item controller: 'accounts/profiles', html_options: {class: "nav-item"} do %>

--- a/app/views/layouts/sidebars/_admin.html.erb
+++ b/app/views/layouts/sidebars/_admin.html.erb
@@ -1,4 +1,4 @@
-<div class="sidebar">
+<div class="sidebar" data-controller="coreui-sidebar">
   <nav class="sidebar-nav">
     <ul class="nav">
       <%= nav_item controller: 'admin/home', html_options: {class: "nav-item"} do %>

--- a/app/views/layouts/sidebars/_application.html.erb
+++ b/app/views/layouts/sidebars/_application.html.erb
@@ -1,4 +1,4 @@
-<div class="sidebar">
+<div class="sidebar" data-controller="coreui-sidebar">
   <div class="sidebar-header">
     <%= link_to root_path, class: "nav-link" do %>
       <i class="fas fa-home"></i>


### PR DESCRIPTION
I guess due to upstream @coreui/coreui not consider the turbolink at all.

cybros_portal/node_modules/@coreui/coreui/js/src/sidebar.js

```js
$(document).on(Event.CLICK, Selector.SIDEBAR_MINIMIZER, (event) => {
        event.preventDefault()
        event.stopPropagation()
        $(Selector.BODY).toggleClass(ClassName.SIDEBAR_MINIMIZED)
        this.perfectScrollbar(Event.TOGGLE)
      })
```

<img width="1285" alt="WechatIMG10" src="https://user-images.githubusercontent.com/1131536/56862136-5452a480-69da-11e9-9572-5ad49e854ce4.png">
